### PR TITLE
Removed purge warnings

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,4 +12,5 @@ module.exports = {
   },
   variants: {},
   plugins: [],
+  purge: false,
 };


### PR DESCRIPTION
Currently, when you build this branch, there is a warning regarding Tailwind not removing all unused CSS. I have not gone through every component, but to suppress this warning, we simply need to add purge: false. If we should in fact be purging specific files or directories, we can change this to an array providing those as documented here: https://tailwindcss.com/docs/optimizing-for-production.