### PR TITLE
Adding the update call to get rid of the warnings

### DIFF
--- a/scripts/npm/build.sh
+++ b/scripts/npm/build.sh
@@ -4,5 +4,6 @@
 # If there's no git repository, surpress git errors and use the current directory
 REPO_ROOT=$( git rev-parse --show-toplevel 2> /dev/null || echo . )
 
+npx browserslist@latest --update-db
 $REPO_ROOT/scripts/npm/generateapidoc.sh
 npx next build $REPO_ROOT

--- a/scripts/npm/generateapidoc.sh
+++ b/scripts/npm/generateapidoc.sh
@@ -4,4 +4,5 @@
 # If there's no git repository, surpress git errors and use the current directory
 REPO_ROOT=$( git rev-parse --show-toplevel 2> /dev/null || echo . )
 
+npx browserslist@latest --update-db
 npx apidoc -i $REPO_ROOT -e node_modules/ -o .build/apidoc/


### PR DESCRIPTION
The current browser database is out of date and adding this to the build process ensures we have the most up-to-date.