### PR TITLE
Fix incorrect path

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "VIDEO_INPUT": "TO_REPLACE_VIDEO_INPUT",
   "NEURAL_NETWORK": "TO_REPLACE_NEURAL_NETWORK",
   "VIDEO_INPUTS_PARAMS": {
-    "file": "opendatacam_videos/demo.mp4",
+    "file": "opendatacam_videos_uploaded/demo.mp4",
     "usbcam": "v4l2src device=/dev/video0 ! video/x-raw, framerate=30/1, width=640, height=360 ! videoconvert ! appsink",
     "raspberrycam": "nvarguscamerasrc ! video/x-raw(memory:NVMM),width=1280, height=720, framerate=30/1, format=NV12 ! nvvidconv ! video/x-raw, format=BGRx, width=640, height=360 ! videoconvert ! video/x-raw, format=BGR ! appsink",
     "remote_cam": "YOUR IP CAM STREAM (can be .m3u8, MJPEG ...), anything supported by opencv",


### PR DESCRIPTION
A default install will fail due to the path being incorrect. This also does not address that the demo file that is mentioned is not saved in the directory, so probably need to fix that too or get clarification if that is not supposed to be there.