### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/run/nano/docker-compose.yml
+++ b/docker/run/nano/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8070:8070"
       - "8090:8090"
   mongo:
-    image: mongo
+    image: mongo:4.2.14
     restart: always
     ports:
       - "27017:27017"


### PR DESCRIPTION
Based on https://github.com/opendatacam/opendatacam/issues/495, this PR locks mongo to 4.2.14 as mongo 5 multiverse AMR64, i.e. Mongo:latest does not run on Jetsons.  It will install but fail to start.